### PR TITLE
Fix IPv4 connection handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -1145,6 +1145,10 @@ int main(int argc, char **argv)
     if (params.baddr.sa.sa_family != AF_INET6) {
         params.ipv6 = 0;
     }
+    if (!params.ipv6 && params.baddr.sa.sa_family == AF_INET6) {
+        params.baddr.sa.sa_family = AF_INET;
+        params.baddr.in.sin_addr.s_addr = INADDR_ANY;
+    }
     if (!params.def_ttl) {
         if ((params.def_ttl = get_default_ttl()) < 1) {
             clear_params();


### PR DESCRIPTION
## Summary
- ensure IPv4 connections succeed when `--no-ipv6` is used by adjusting the bind address

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_684063ab1f38832dbb90a232e71e1b7a